### PR TITLE
fix: Adds default data directory for CLI search commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2025-09-27
+
+### Fixed
+
+- CLI search commands now work without requiring `--data-dir` argument
+- Commands use the same default path as `glazing init` (`~/.local/share/glazing/converted/`)
+- Updated help text to show default directory path
+
 ### Changed
 
 - Improved documentation clarity and conciseness

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -118,7 +118,7 @@ except ValidationError as e:
 
 ## Version Compatibility
 
-This documentation covers Glazing version 0.1.0. Check your installed version:
+This documentation covers Glazing version 0.1.1. Check your installed version:
 
 ```python
 import glazing

--- a/docs/citation.md
+++ b/docs/citation.md
@@ -12,22 +12,22 @@ If you use Glazing in your research, please cite our work.
   title = {Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies},
   year = {2025},
   url = {https://github.com/aaronstevenwhite/glazing},
-  version = {0.1.0},
+  version = {0.1.1},
   doi = {10.5281/zenodo.17185626}
 }
 ```
 
 ### APA
 
-White, A. S. (2025). *Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies* (Version 0.1.0) [Computer software]. https://github.com/aaronstevenwhite/glazing
+White, A. S. (2025). *Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies* (Version 0.1.1) [Computer software]. https://github.com/aaronstevenwhite/glazing
 
 ### Chicago
 
-White, Aaron Steven. 2025. *Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies*. Version 0.1.0. https://github.com/aaronstevenwhite/glazing.
+White, Aaron Steven. 2025. *Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies*. Version 0.1.1. https://github.com/aaronstevenwhite/glazing.
 
 ### MLA
 
-White, Aaron Steven. *Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies*. Version 0.1.0, 2025, https://github.com/aaronstevenwhite/glazing.
+White, Aaron Steven. *Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies*. Version 0.1.1, 2025, https://github.com/aaronstevenwhite/glazing.
 
 ## Citing Datasets
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -93,7 +93,7 @@ If you use Glazing in your research, please cite:
   title = {Glazing: Unified Data Models and Interfaces for Syntactic and Semantic Frame Ontologies},
   year = {2025},
   url = {https://github.com/aaronstevenwhite/glazing},
-  version = {0.1.0},
+  version = {0.1.1},
   doi = {10.5281/zenodo.17185626}
 }
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "glazing"
-version = "0.1.0"
+version = "0.1.1"
 description = "Unified data models and interfaces for syntactic and semantic frame ontologies"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/src/glazing/__version__.py
+++ b/src/glazing/__version__.py
@@ -1,4 +1,4 @@
 """Version information for the glazing package."""
 
-__version__ = "0.1.0"
+__version__ = "0.1.1"
 __version_info__ = tuple(int(i) for i in __version__.split("."))

--- a/src/glazing/cli/search.py
+++ b/src/glazing/cli/search.py
@@ -28,6 +28,7 @@ from rich.table import Table
 from rich.tree import Tree
 
 from glazing.framenet.models import Frame
+from glazing.initialize import get_default_data_path
 from glazing.propbank.models import Frameset
 from glazing.search import SearchResult, UnifiedSearch
 from glazing.verbnet.models import VerbClass
@@ -174,8 +175,9 @@ def search() -> None:
 @click.option(
     "--data-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    required=True,
-    help="Directory containing converted JSON Lines files.",
+    default=lambda: get_default_data_path(),
+    help="Directory containing converted JSON Lines files "
+    "(default: ~/.local/share/glazing/converted).",
 )
 @click.option(
     "--dataset",
@@ -291,8 +293,9 @@ def search_query(
 @click.option(
     "--data-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    required=True,
-    help="Directory containing converted JSON Lines files.",
+    default=lambda: get_default_data_path(),
+    help="Directory containing converted JSON Lines files "
+    "(default: ~/.local/share/glazing/converted).",
 )
 @click.option(
     "--json",
@@ -343,8 +346,9 @@ def get_entity(
 @click.option(
     "--data-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    required=True,
-    help="Directory containing converted JSON Lines files.",
+    default=lambda: get_default_data_path(),
+    help="Directory containing converted JSON Lines files "
+    "(default: ~/.local/share/glazing/converted).",
 )
 @click.option(
     "--dataset",
@@ -427,8 +431,9 @@ def search_role(
 @click.option(
     "--data-dir",
     type=click.Path(exists=True, file_okay=False, dir_okay=True),
-    required=True,
-    help="Directory containing converted JSON Lines files.",
+    default=lambda: get_default_data_path(),
+    help="Directory containing converted JSON Lines files "
+    "(default: ~/.local/share/glazing/converted).",
 )
 def find_cross_ref(
     source: str,


### PR DESCRIPTION
## Summary

Fixes CLI search commands to work without requiring `--data-dir` argument by using the same default path as `glazing init`.

## Key Changes

- **Added default path**: Search commands now default to `~/.local/share/glazing/converted/`
- **Updated 4 CLI commands**: `search query`, `search entity`, `search role`, `search cross-ref`
- **Version bump**: 0.1.0 → 0.1.1 (patch release for bug fix)

## Problem

CLI commands failed with "Missing option '--data-dir'" despite README examples suggesting the argument was optional.

## Solution

Import `get_default_data_path()` from `glazing.initialize` and use it as the default value for all search command `--data-dir` options.

## Impact

- Users can now run `glazing search query "abandon"` without specifying data directory
- Commands work as documented in README
- No breaking changes: existing commands with explicit `--data-dir` still work
- All tests pass (`pytest`, `mypy --strict`, `ruff check`, `ruff format`)

## Files Changed
  
- `src/glazing/cli/search.py` - Added default data directory support
- `pyproject.toml`, `src/glazing/__version__.py` version bump
- Documentation files: Updated version references
- `CHANGELOG.md`: Added 0.1.1 entry